### PR TITLE
fixing Transition components

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,36 +6,30 @@ export default function Home() {
       <>
         <div className="h-screen flex overflow-hidden bg-white">
           <div className="md:hidden">
-            <div className="fixed inset-0 flex z-40">
+            <Transition show={isOpen} className="fixed inset-0 flex z-40">
 
-              <Transition
-                  show={isOpen}
+              <Transition.Child
                   enter="transition-opacity easeLinear duration-300"
                   enterFrom="opacity-0"
                   enterTo="opacity-100"
                   leave="transition-opacity easeLinear duration-300"
                   leaveFrom="opacity-100"
                   leaveTo="opacity-0"
+                  className="fixed inset-0"
               >
-
-                <div className="fixed inset-0">
-                  <div className="absolute inset-0 bg-gray-600 opacity-75">
-                  </div>
-
-                </div>
-              </Transition>
+                  <div className="absolute inset-0 bg-gray-600 opacity-75"></div>
+              </Transition.Child>
 
 
-              <Transition
-                  show={isOpen}
+              <Transition.Child
                   enter="transition ease-in-out duration-300 transform"
                   enterFrom="-translate-x-full"
                   enterTo="translate-x-0"
                   leave="transition ease-in-out duration-300 transform"
                   leaveFrom="translate-x-0"
                   leaveTo="-translate-x-full"
+                  className="relative flex-1 flex flex-col max-w-xs w-full bg-white"
               >
-                <div className="relative flex-1 flex flex-col max-w-xs w-full bg-white">
                   <div className="absolute top-0 right-0 -mr-14 p-1">
                     <button onClick={() => setIsOpen(!isOpen)}
                             className="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600"
@@ -146,12 +140,9 @@ export default function Home() {
                       </div>
                     </a>
                   </div>
-                </div>
-              </Transition>
-              <div className="flex-shrink-0 w-14">
-
-              </div>
-            </div>
+              </Transition.Child>
+            </Transition>
+            <div className="flex-shrink-0 w-14"></div>
           </div>
 
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,8 +5,8 @@ export default function Home() {
   return (
       <>
         <div className="h-screen flex overflow-hidden bg-white">
-          <div className="md:hidden">
-            <Transition show={isOpen} className="fixed inset-0 flex z-40">
+          <Transition show={isOpen} className="md:hidden">
+            <div className="fixed inset-0 flex z-40">
 
               <Transition.Child
                   enter="transition-opacity easeLinear duration-300"
@@ -20,7 +20,6 @@ export default function Home() {
                   <div className="absolute inset-0 bg-gray-600 opacity-75"></div>
               </Transition.Child>
 
-
               <Transition.Child
                   enter="transition ease-in-out duration-300 transform"
                   enterFrom="-translate-x-full"
@@ -30,6 +29,7 @@ export default function Home() {
                   leaveTo="-translate-x-full"
                   className="relative flex-1 flex flex-col max-w-xs w-full bg-white"
               >
+                
                   <div className="absolute top-0 right-0 -mr-14 p-1">
                     <button onClick={() => setIsOpen(!isOpen)}
                             className="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600"
@@ -140,10 +140,13 @@ export default function Home() {
                       </div>
                     </a>
                   </div>
+             
               </Transition.Child>
-            </Transition>
-            <div className="flex-shrink-0 w-14"></div>
-          </div>
+              <div className="flex-shrink-0 w-14">
+
+              </div>
+            </div>
+          </Transition>
 
 
           <div className="hidden md:flex md:flex-shrink-0">


### PR DESCRIPTION
Hey!

These changes should fix your mobile sidebar issues. A few comments:

The first important thing is the elements wrapped in `Transition` components here are **Flex children**, in the sense that they are immediate children from an element with a `flex` class applied.

The `Transition` component outputs an extra wrapping `div` in your markup, and this throws off the layout as the hierarchy of flex children is changed.

For that reason, I moved the classes applied to the `wrapped element` directly on the Transition component, so that Transition `div` becomes the flex child. Makes sense?

Also - and apologies for that - we had a mistake in our code comments positioning:

In this component, we actually show/hide the `off-canvas menu` wrapping div:

![image](https://user-images.githubusercontent.com/485747/94668786-cf4c8700-0353-11eb-8008-3f02476d8aa2.png)

The element we show/hide is actually the one above the comment - this is something we need to fix and I can see how it would have been confusing - sorry 😅

Let me know if you have questions, and I hope this is helpful to you! 